### PR TITLE
Fix extglob patterns matching valid paths and update tests.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,10 @@
  * Licensed under the MIT License.
  */
 
+ var isExtglob = require('is-extglob');
+
 module.exports = function isGlob(str) {
   return typeof str === 'string'
-    && /[@!*+{}?(|)[\]]/.test(str);
+    && (/[*!?{}(|)[\]]/.test(str)
+     || isExtglob(str));
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "mocha": "*",
-    "should": "*"
+    "should": "^7.1.0"
   },
   "keywords": [
     "bash",
@@ -43,5 +43,8 @@
     "regular",
     "string",
     "test"
-  ]
+  ],
+  "dependencies": {
+    "is-extglob": "^1.0.0"
+  }
 }

--- a/test.js
+++ b/test.js
@@ -13,58 +13,61 @@ var isGlob = require('./');
 
 describe('isGlob', function () {
   it('should return `true` if it is a glob pattern:', function () {
-    isGlob('*.js').should.be.true;
-    isGlob('!*.js').should.be.true;
-    isGlob('!foo').should.be.true;
-    isGlob('!foo.js').should.be.true;
-    isGlob('**/abc.js').should.be.true;
-    isGlob('abc/*.js').should.be.true;
+    isGlob('*.js').should.be.true();
+    isGlob('!*.js').should.be.true();
+    isGlob('!foo').should.be.true();
+    isGlob('!foo.js').should.be.true();
+    isGlob('**/abc.js').should.be.true();
+    isGlob('abc/*.js').should.be.true();
   });
 
   it('should return `true` if the path has brace characters:', function () {
-    isGlob('abc/{a,b}.js').should.be.true;
-    isGlob('abc/{a..z}.js').should.be.true;
-    isGlob('abc/{a..z..2}.js').should.be.true;
+    isGlob('abc/{a,b}.js').should.be.true();
+    isGlob('abc/{a..z}.js').should.be.true();
+    isGlob('abc/{a..z..2}.js').should.be.true();
   });
 
   it('should return `true` if it has an extglob:', function () {
-    isGlob('abc/@(a).js').should.be.true;
-    isGlob('abc/!(a).js').should.be.true;
-    isGlob('abc/+(a).js').should.be.true;
-    isGlob('abc/*(a).js').should.be.true;
-    isGlob('abc/?(a).js').should.be.true;
+    isGlob('abc/@(a).js').should.be.true();
+    isGlob('abc/!(a).js').should.be.true();
+    isGlob('abc/+(a).js').should.be.true();
+    isGlob('abc/*(a).js').should.be.true();
+    isGlob('abc/?(a).js').should.be.true();
   });
 
-  it('should return `true` if it has extglob characters:', function () {
-    isGlob('abc/@.js').should.be.true;
-    isGlob('abc/!.js').should.be.true;
-    isGlob('abc/+.js').should.be.true;
-    isGlob('abc/*.js').should.be.true;
-    isGlob('abc/?.js').should.be.true;
+  it('should return `true` if it has extglob characters and is not valid path:', function () {
+    isGlob('abc/!.js').should.be.true();
+    isGlob('abc/*.js').should.be.true();
+    isGlob('abc/?.js').should.be.true();
+  });
+
+  it('should return `false` if it has extglob characters but is a valid path:', function () {
+    isGlob('abc/@.js').should.be.false();
+    isGlob('abc/+.js').should.be.false();
   });
 
   it('should return `true` if the path has regex characters:', function () {
-    isGlob('abc/(aaa|bbb).js').should.be.true;
-    isGlob('abc/?.js').should.be.true;
-    isGlob('?.js').should.be.true;
-    isGlob('[abc].js').should.be.true;
-    isGlob('[^abc].js').should.be.true;
-    isGlob('a/b/c/[a-z].js').should.be.true;
-    isGlob('[a-j]*[^c]b/c').should.be.true;
+    isGlob('abc/(aaa|bbb).js').should.be.true();
+    isGlob('abc/?.js').should.be.true();
+    isGlob('?.js').should.be.true();
+    isGlob('[abc].js').should.be.true();
+    isGlob('[^abc].js').should.be.true();
+    isGlob('a/b/c/[a-z].js').should.be.true();
+    isGlob('[a-j]*[^c]b/c').should.be.true();
   });
 
   it('should return `false` if it is not a string:', function () {
-    isGlob().should.be.false;
-    isGlob(null).should.be.false;
-    isGlob(['**/*.js']).should.be.false;
-    isGlob(['foo.js']).should.be.false;
+    isGlob().should.be.false();
+    isGlob(null).should.be.false();
+    isGlob(['**/*.js']).should.be.false();
+    isGlob(['foo.js']).should.be.false();
   });
 
   it('should return `false` if it is not a glob pattern:', function () {
-    isGlob('.').should.be.false;
-    isGlob('aa').should.be.false;
-    isGlob('abc.js').should.be.false;
-    isGlob('abc/def/ghi.js').should.be.false;
+    isGlob('.').should.be.false();
+    isGlob('aa').should.be.false();
+    isGlob('abc.js').should.be.false();
+    isGlob('abc/def/ghi.js').should.be.false();
   });
 });
 


### PR DESCRIPTION
Hi,

`isGlob` was currently matching things like `@mypath` as a glob, but `@mypath` being a perfectly
valid path, even with `extglob` on, I think it shoud not match.
Here is the bash documentation about this.
https://www.gnu.org/software/bash/manual/html_node/Pattern-Matching.html

I updated to match `@(my|pattern)` as a glob, but not `@mypath`. I did the same for paths with `+`.

This is actually causing an issue in [chokidar](https://github.com/paulmillr/chokidar) (which relies implicitly on this through [glob-parent](https://github.com/es128/glob-parent)),
as `path/to/@mydir` is not treated as it should be.

Also, from `should.js` 0.7, `should.be.true` like matchers [all became functions](https://github.com/shouldjs/should.js/blob/master/History.md#700--2015-06-18) so I modified the tests,
otherwise they would become noop as the version of should.js was not locked.

Thanks.